### PR TITLE
Fix generating lingua.selector url to other language on HTTPS

### DIFF
--- a/core/components/lingua/elements/snippets/lingua.selector.snippet.php
+++ b/core/components/lingua/elements/snippets/lingua.selector.snippet.php
@@ -51,7 +51,7 @@ if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
     $pageURL .= "s";
 }
 $pageURL .= "://";
-if ($_SERVER["SERVER_PORT"] !== "80") {
+if ($_SERVER["SERVER_PORT"] !== "80" && $_SERVER["SERVER_PORT"] !== "443") {
     $pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
 } else {
     $pageURL .= $_SERVER["SERVER_NAME"] . $_SERVER["REQUEST_URI"];


### PR DESCRIPTION
Line 208 of the `lingua.selector` snippet has the following `preg_replace` to generate the other language url:

```
$pageURL = preg_replace('/^' . preg_quote($parseUrl['scheme'] . '://' . $parseUrl['host'] . '/' . $requestUri, '/') . '/i'
       , $parseUrl['scheme'] . '://' . $parseUrl['host'] . '/' . $baseUrl . $itemUri
       , $originPageUrl);
```

That's trying to find `$parseUrl['scheme'] . '://' . $parseUrl['host'] . '/' . $requestUri` in `$originPageUrl`, to replace it with the (correct) `$parseUrl['scheme'] . '://' . $parseUrl['host'] . '/' . $baseUrl . $itemUri`.

Because HTTPS is (transparently) served on port 443, the port is injected into `$pageURL` here in line 55 and therefore around line 175 into the subject of this replace, `$originPageUrl`. 

Because `$parseUrl['host']` does **not** have the port, the `preg_replace` fails and the user is given **the current link with `?lang=foo` added**. While that works to switch the language, the user wants to see the proper localised url and not the current one. 

By not adding the port if it's 443, the preg_replace matches as expected and the right URL is returned. 